### PR TITLE
Support postEvent Sailthru API call

### DIFF
--- a/src/SailthruMessage.php
+++ b/src/SailthruMessage.php
@@ -66,6 +66,11 @@ class SailthruMessage
     protected $isMultiSend = false;
 
     /**
+     * @var bool
+     */
+    protected $isEvent = false;
+
+    /**
      * @var array
      */
     protected $options = [];
@@ -369,5 +374,26 @@ class SailthruMessage
     public function isMultiSend(): bool
     {
         return $this->isMultiSend;
+    }
+
+    /**
+     * @param string $useEvent
+     *
+     * @return SailthruMessage
+     */
+    public function setIsEvent(
+        bool $useEventApi
+    ): SailthruMessage {
+        $this->isEvent = $useEventApi;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useEvent(): bool
+    {
+        return $this->isEvent;
     }
 }


### PR DESCRIPTION
Done in a way that is backwards compatible by adding a property on the message class and using the to-email, template, and vars as the parameters.